### PR TITLE
Apply MAA update, suppress build warning

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,8 @@ fn main() {
 		image.write_with_encoder(PngEncoder::new(&mut stdout)).unwrap();
 	} else if command.contains("am force-stop") {
 		terminate();
+	} else if command.contains("shell getprop ro.build.version.release") {
+		println!("14") // Dummy
 	}
 }
 
@@ -153,13 +155,13 @@ fn capture() -> DynamicImage {
 		let cbmp = CreateCompatibleBitmap(dc, width, height);
 
 		SelectObject(cdc, cbmp);
-		PrintWindow(main, cdc, PRINT_WINDOW_FLAGS(PW_CLIENTONLY.0 | PW_RENDERFULLCONTENT));
+		let _ = PrintWindow(main, cdc, PRINT_WINDOW_FLAGS(PW_CLIENTONLY.0 | PW_RENDERFULLCONTENT));
 		GetDIBits(cdc, cbmp, 0, height as u32, Some(buffer.as_mut_ptr() as *mut _), &mut info, DIB_RGB_COLORS);
 		
-		DeleteObject(cbmp);
+		_ = DeleteObject(cbmp);
 		ReleaseDC(main, dc);
-		DeleteDC(dc);
-		DeleteDC(cdc);
+		_ = DeleteDC(dc);
+		_ = DeleteDC(cdc);
 	}
 
 	let mut chunks: Vec<Vec<u8>> = buffer.chunks(width as usize * 4).map(|x| x.to_vec()).collect();


### PR DESCRIPTION
MAA : v5.3.0-beta.3 (beta latest)

```text
[2024-05-25 15:37:47.975][INF][Px8a34][Tx6a40] Call ` ......\PlayBridge.exe -s 127.0.0.1:5555 shell getprop ro.build.version.release ` ret 0 , cost 16 ms , stdout size: 0 , socket size: 0
```

MAA crashes after this log with "External component has thrown an exception."


:)