### PR TITLE
MAA "Login" feature problem fix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,11 @@ fn main() {
 		terminate();
 	} else if command.contains("shell getprop ro.build.version.release") {
 		println!("14") // Dummy
+	} else if command.contains("shell am start -n") {
+		// command to startup game
+		let intent = args[7].parse::<String>().unwrap();
+		println!("Starting: Intent {{ cmp={} }}", intent);
+		println!("Warning: Activity not started, intent has been delivered to currently running top-most instance.");
 	}
 }
 


### PR DESCRIPTION
MAA log:
```
[2024-06-01 21:49:02.211][INF][Px1b0c][Tx1554] Call ` ...\adb.exe -s ... shell am start -n com.YoStarKR.Arknights/com.u8.sdk.U8UnityContext ` ret 0 , cost 83 ms , stdout size: 173 , socket size: 0
[2024-06-01 21:49:02.211][TRC][Px1b0c][Tx1554] stdout output:
Starting: Intent { cmp=com.YoStarKR.Arknights/com.u8.sdk.U8UnityContext }
Warning: Activity not started, intent has been delivered to currently running top-most instance.

[2024-06-01 21:49:02.211][INF][Px1b0c][Tx1554] Assistant::append_callback | SubTaskCompleted {"class":"asst::StartGameTaskPlugin","details":{},"subtask":"StartGameTask","taskchain":"StartUp","taskid":21,"uuid":""}
```

MAA tries to start Arknights app context and wait until it activated.